### PR TITLE
AssetPublisher now supports empty baseUrl

### DIFF
--- a/config/test.php
+++ b/config/test.php
@@ -22,6 +22,7 @@ return [
         '@npm' => '@root/node_modules',
         '@view' => '@public/view',
         '@web' => '@baseUrl',
+        '@webRoot' => '/',
         '@testSourcePath' => '@public/assetsources'
     ],
 

--- a/src/AssetPublisher.php
+++ b/src/AssetPublisher.php
@@ -505,14 +505,14 @@ final class AssetPublisher implements AssetPublisherInterface
      */
     private function checkBaseUrl(?string $baseUrl): void
     {
-        if (!isset($this->baseUrl) && !isset($baseUrl)) {
+        if (!isset($this->baseUrl) && $baseUrl === null) {
             throw new InvalidConfigException(
                 'baseUrl must be set in AssetPublisher->setBaseUrl($path) or ' .
                 'AssetBundle property public ?string $baseUrl = $path'
             );
         }
 
-        if (isset($baseUrl)) {
+        if ($baseUrl !== null) {
             $this->baseUrl = $this->aliases->get($baseUrl);
         }
     }

--- a/src/AssetPublisher.php
+++ b/src/AssetPublisher.php
@@ -505,14 +505,14 @@ final class AssetPublisher implements AssetPublisherInterface
      */
     private function checkBaseUrl(?string $baseUrl): void
     {
-        if (empty($this->baseUrl) && empty($baseUrl)) {
+        if (!isset($this->baseUrl) && !isset($baseUrl)) {
             throw new InvalidConfigException(
                 'baseUrl must be set in AssetPublisher->setBaseUrl($path) or ' .
                 'AssetBundle property public ?string $baseUrl = $path'
             );
         }
 
-        if (!empty($baseUrl)) {
+        if (isset($baseUrl)) {
             $this->baseUrl = $this->aliases->get($baseUrl);
         }
     }

--- a/tests/AssetBundleTest.php
+++ b/tests/AssetBundleTest.php
@@ -11,6 +11,7 @@ use Yiisoft\Assets\Tests\stubs\CircleAsset;
 use Yiisoft\Assets\Tests\stubs\CircleDependsAsset;
 use Yiisoft\Assets\Tests\stubs\FileOptionsAsset;
 use Yiisoft\Assets\Tests\stubs\JqueryAsset;
+use Yiisoft\Assets\Tests\stubs\RootAsset;
 use Yiisoft\Assets\Tests\stubs\SimpleAsset;
 
 /**
@@ -78,7 +79,40 @@ final class AssetBundleTest extends TestCase
         $this->assetManager->register([BaseAsset::class]);
     }
 
-    public function testBaseUrlEmptyException(): void
+    public function testBaseUrlEmptyString(): void
+    {
+        $this->assetManager->setBundles(
+            [
+                RootAsset::class => [
+                    'baseUrl' => ''
+                ],
+            ]
+        );
+
+        $this->assertEmpty($this->assetManager->getAssetBundles());
+
+        $this->assetManager->register([RootAsset::class]);
+    }
+
+    public function testBaseUrlEmptyStringChain(): void
+    {
+        $this->assetManager->setBundles(
+            [
+                RootAsset::class => [
+                    'depends' => [BaseAsset::class]
+                ],
+                BaseAsset::class => [
+                    'baseUrl' => null,
+                ],
+            ]
+        );
+
+        $this->assertEmpty($this->assetManager->getAssetBundles());
+
+        $this->assetManager->register([RootAsset::class]);
+    }
+
+    public function testBaseUrlIsNotSetException(): void
     {
         $this->assetManager->setBundles(
             [

--- a/tests/stubs/RootAsset.php
+++ b/tests/stubs/RootAsset.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Yiisoft\Assets\Tests\stubs;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class RootAsset extends AssetBundle
+{
+    public ?string $basePath = '@public';
+
+    public ?string $baseUrl = '@webRoot';
+
+    public array $js = [
+        'root.js',
+    ];
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️


```php
$params['aliases'] = [
    '@web' => '/',
];
class AppAsset extends AssetBundle
{
    # ...
    public ?string $baseUrl = '@web';
    # ....
}
```

When we will get `@web` path the `Aliases` class will return an empty string.
This value [will be writen](https://github.com/yiisoft/assets/blob/f935c265f5699832fb30b72417e930fde71942db/src/AssetPublisher.php#L516) in the `AssetPublisher->baseUrl` property.
In this case the condition on [this line](https://github.com/yiisoft/assets/blob/f935c265f5699832fb30b72417e930fde71942db/src/AssetPublisher.php#L508) can be met and it's fail.

Also somebody can manually specify empty string in the `$baseUrl` property of the `AssetBundle`. This somebody might just want to specify root of web dir.