### PR TITLE
Fix phpunit deprecated assertFileNotExists.

### DIFF
--- a/tests/AssetPublisherTest.php
+++ b/tests/AssetPublisherTest.php
@@ -327,7 +327,7 @@ final class AssetPublisherTest extends TestCase
 
         $notNeededFilesDir = dirname($bundle->basePath . DIRECTORY_SEPARATOR . $bundle->css[0]);
 
-        $this->assertFileNotExists($notNeededFilesDir);
+        $this->assertFileDoesNotExist($notNeededFilesDir);
 
         foreach ($bundle->js as $filename) {
             $publishedFile = $bundle->basePath . DIRECTORY_SEPARATOR . $filename;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

