### PR TITLE
Fix CDN

### DIFF
--- a/src/AssetPublisher.php
+++ b/src/AssetPublisher.php
@@ -180,7 +180,9 @@ final class AssetPublisher implements AssetPublisherInterface
         }
 
         if ($bundle->cdn) {
-            return $this->baseUrl . '/' . $assetPath;
+            return $bundle->baseUrl === null
+                ? $assetPath
+                : $bundle->baseUrl . '/' . $assetPath;
         }
 
         if (!AssetUtil::isRelative($assetPath) || strncmp($assetPath, '/', 1) === 0) {

--- a/tests/AssetPublisherTest.php
+++ b/tests/AssetPublisherTest.php
@@ -7,6 +7,8 @@ namespace Yiisoft\Assets\Tests;
 use Yiisoft\Assets\AssetPublisher;
 use Yiisoft\Assets\Exception\InvalidConfigException;
 use Yiisoft\Assets\Tests\stubs\BaseAsset;
+use Yiisoft\Assets\Tests\stubs\CdnAsset;
+use Yiisoft\Assets\Tests\stubs\CdnWithBaseUrlAsset;
 use Yiisoft\Assets\Tests\stubs\JqueryAsset;
 use Yiisoft\Assets\Tests\stubs\SourceAsset;
 use Yiisoft\Assets\Tests\stubs\WithoutBaseAsset;
@@ -414,5 +416,21 @@ final class AssetPublisherTest extends TestCase
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessageMatches('/^basePath must be set in AssetPublisher->setBasePath\(\$path\)/');
         $publisher->publish(new WithoutBaseAsset());
+    }
+
+    public function testCdn(): void
+    {
+        $publisher = new AssetPublisher($this->aliases);
+        $publisher->setBaseUrl('https://example.com/test');
+
+        $this->assertSame(
+            'https://example.com/main.css',
+            $publisher->getAssetUrl(new CdnAsset(), 'https://example.com/main.css')
+        );
+
+        $this->assertSame(
+            'https://example.com/base/main.css',
+            $publisher->getAssetUrl(new CdnWithBaseUrlAsset(), 'main.css')
+        );
     }
 }

--- a/tests/stubs/CdnAsset.php
+++ b/tests/stubs/CdnAsset.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Assets\Tests\stubs;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class CdnAsset extends AssetBundle
+{
+    public bool $cdn = true;
+
+    public array $js = [
+        'https://example.com/script.js',
+    ];
+}

--- a/tests/stubs/CdnWithBaseUrlAsset.php
+++ b/tests/stubs/CdnWithBaseUrlAsset.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Assets\Tests\stubs;
+
+use Yiisoft\Assets\AssetBundle;
+
+final class CdnWithBaseUrlAsset extends AssetBundle
+{
+    public bool $cdn = true;
+    public ?string $baseUrl = 'https://example.com/base';
+
+    public array $js = [
+        'script.js',
+    ];
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #53

If asset checked as CDN, then for make URL don't use publisher base url.