### PR TITLE
Make objects immutable, add AssetManager::getAssetUrl() method

### DIFF
--- a/config/params.php
+++ b/config/params.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 return [
     'yiisoft/assets' => [
         'assetConverter' => [
-            'command' => [
-                'from' => 'scss',
-                'to' => 'css',
-                'command' => '@npm/.bin/sass {options} {from} {to}',
+            'commands' => [
+                'scss' => ['css', '@npm/.bin/sass {options} {from} {to}'],
             ],
             'forceConvert' => false,
         ],

--- a/config/web.php
+++ b/config/web.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Yiisoft\Aliases\Aliases;
 use Yiisoft\Assets\AssetConverter;
 use Yiisoft\Assets\AssetConverterInterface;
@@ -17,38 +19,48 @@ use Yiisoft\Factory\Definition\Reference;
 return [
     AssetConverterInterface::class => [
         'class' => AssetConverter::class,
-        'setCommand()' => [
-            $params['yiisoft/assets']['assetConverter']['command']['from'],
-            $params['yiisoft/assets']['assetConverter']['command']['to'],
-            $params['yiisoft/assets']['assetConverter']['command']['command'],
+        '__construct()' => [
+            Reference::to(Aliases::class),
+            Reference::to(LoggerInterface::class),
+            $params['yiisoft/assets']['assetConverter']['commands'],
+            $params['yiisoft/assets']['assetConverter']['forceConvert'],
         ],
-        'setForceConvert()' => [$params['yiisoft/assets']['assetConverter']['forceConvert']],
     ],
 
     AssetLoaderInterface::class => [
         'class' => AssetLoader::class,
-        'setAppendTimestamp()' => [$params['yiisoft/assets']['assetLoader']['appendTimestamp']],
-        'setAssetMap()' => [$params['yiisoft/assets']['assetLoader']['assetMap']],
-        'setBasePath()' => [$params['yiisoft/assets']['assetLoader']['basePath']],
-        'setBaseUrl()' => [$params['yiisoft/assets']['assetLoader']['baseUrl']],
+        '__construct()' => [
+            Reference::to(Aliases::class),
+            $params['yiisoft/assets']['assetLoader']['appendTimestamp'],
+            $params['yiisoft/assets']['assetLoader']['assetMap'],
+            $params['yiisoft/assets']['assetLoader']['basePath'],
+            $params['yiisoft/assets']['assetLoader']['baseUrl'],
+        ],
     ],
 
     AssetPublisherInterface::class => [
         'class' => AssetPublisher::class,
-        'setForceCopy()' => [$params['yiisoft/assets']['assetPublisher']['forceCopy']],
-        'setLinkAssets()' => [$params['yiisoft/assets']['assetPublisher']['linkAssets']],
-    ],
-
-    AssetManager::class => [
-        'class' => AssetManager::class,
         '__construct()' => [
             Reference::to(Aliases::class),
-            Reference::to(AssetLoaderInterface::class),
+            $params['yiisoft/assets']['assetPublisher']['forceCopy'],
+            $params['yiisoft/assets']['assetPublisher']['linkAssets'],
+        ],
+    ],
+
+    AssetManager::class => static function (ContainerInterface $container) use ($params):AssetManager {
+        $assetManager = new AssetManager(
+            $container->get(Aliases::class),
+            $container->get(AssetLoaderInterface::class),
             $params['yiisoft/assets']['assetManager']['allowedBundleNames'],
             $params['yiisoft/assets']['assetManager']['customizedBundles'],
-        ],
-        'setPublisher()' => [Reference::to(AssetPublisherInterface::class)],
-        'setConverter()' => [Reference::to(AssetConverterInterface::class)],
-        'register()' => [$params['yiisoft/assets']['assetManager']['register']],
-    ],
+        );
+
+        $assetManager = $assetManager
+            ->withConverter($container->get(AssetConverterInterface::class))
+            ->withPublisher($container->get(AssetPublisherInterface::class))
+        ;
+
+        $assetManager->register($params['yiisoft/assets']['assetManager']['register']);
+        return $assetManager;
+    },
 ];

--- a/config/web.php
+++ b/config/web.php
@@ -47,7 +47,7 @@ return [
         ],
     ],
 
-    AssetManager::class => static function (ContainerInterface $container) use ($params):AssetManager {
+    AssetManager::class => static function (ContainerInterface $container) use ($params): AssetManager {
         $assetManager = new AssetManager(
             $container->get(Aliases::class),
             $container->get(AssetLoaderInterface::class),

--- a/docs/asset-bundles.md
+++ b/docs/asset-bundles.md
@@ -248,8 +248,8 @@ resolving files stays in the layout.
 
 ### Override file paths for export
 
-By default, all CSS and JavaScript file paths are exported from the asset bundle, but you can specify the list of exported
-file paths explicitly in the `$export` property.
+By default, all CSS and JavaScript file paths are exported from the asset bundle, but
+you can specify the list of exported file paths explicitly in the `$export` property.
 
 ```php
 namespace App\Assets;

--- a/docs/asset-converter.md
+++ b/docs/asset-converter.md
@@ -64,7 +64,16 @@ to CSS. By default, asset converter has command definitions for less, scss, sass
 are meant to be installed globally, and we have it as local dependency, we need to redefine a command:
 
 ```php
-$assetManager->getConverter()->setCommand('scss', ['css', '@npm/.bin/sass {options} {from} {to}']);
+/**
+ * @var \Psr\Log\LoggerInterface $logger
+ * @var \Yiisoft\Aliases\Aliases $aliases
+ * @var \Yiisoft\Assets\AssetManager $assetManager
+ */
+
+$converter = new \Yiisoft\Assets\AssetConverter($aliases, $logger, [
+    'scss' => ['css', '@npm/.bin/sass {options} {from} {to}'],
+]);
+$assetManager = $assetManager->withConverter($converter);
 ```  
 
 or, if done via `yiisoft/di` container:
@@ -73,9 +82,9 @@ or, if done via `yiisoft/di` container:
 AssetConverterInterface::class => static function (\Psr\Container\ContainerInterface $container) {
     $aliases = $container->get(\Yiisoft\Aliases\Aliases::class);
     $logger = $container->get(\Psr\Log\LoggerInterface::class);
-    $converter = new \Yiisoft\Assets\AssetConverter($aliases, $logger);
-    $converter->setCommand('scss', 'css', '@npm/.bin/sass {options} {from} {to}');
-    return $converter;
+    return new \Yiisoft\Assets\AssetConverter($aliases, $logger, [
+        'scss' => ['css', '@npm/.bin/sass {options} {from} {to}'],
+    ]);
 }
 ```
 
@@ -84,10 +93,8 @@ or, if done via params.php:
 ```php
 'yiisoft/assets' => [
     'assetConverter' => [
-        'command' => [
-            'from' => 'scss',
-            'to' => 'css',
-            'command' => '@npm/.bin/sass {options} {from} {to}',
+        'commands' => [
+            'scss' => ['css', '@npm/.bin/sass {options} {from} {to}'],
         ],
         'forceConvert' => false,
     ],

--- a/src/AssetBundle.php
+++ b/src/AssetBundle.php
@@ -154,8 +154,8 @@ class AssetBundle
      * A source asset file is a file that is part of your source code repository of your Web application.
      * You must set this property if the directory containing the source asset files is not Web accessible.
      *
-     * If a publisher is set via {@see AssetManager::setPublisher()}, {@see AssetManager} will publish
-     * the source asset files to a Web-accessible directory automatically when the asset bundle is registered on a page.
+     * If a publisher is set via {@see AssetManager::withPublisher()}, {@see AssetManager} will publish the source
+     * asset files to a Web-accessible directory automatically when the asset bundle is registered on a page.
      *
      * If you do not set this property, it means the source asset files are located under {@see $basePath}.
      *

--- a/src/AssetConverter.php
+++ b/src/AssetConverter.php
@@ -34,15 +34,6 @@ final class AssetConverter implements AssetConverterInterface
      * @var array The commands that are used to perform the asset conversion.
      * The keys are the asset file extension names, and the values are the corresponding
      * target script types (either "css" or "js") and the commands used for the conversion.
-     *
-     * You may also use a {@see https://github.com/yiisoft/docs/blob/master/guide/en/concept/aliases.md}
-     * to specify the location of the command:
-     *
-     * ```php
-     * [
-     *     'styl' => ['css', '@app/node_modules/bin/stylus < {from} > {to}'],
-     * ]
-     * ```
      */
     private array $commands = [
         'less' => ['css', 'lessc {from} {to} --no-color --source-map'],
@@ -55,53 +46,31 @@ final class AssetConverter implements AssetConverterInterface
 
     /**
      * @var bool Whether the source asset file should be converted even if its result already exists.
-     * Default is `false`. You may want to set this to be `true` during the development stage to make
-     * sure the converted assets are always up-to-date. Do not set this to true on production servers
-     * as it will significantly degrade the performance.
      */
     private bool $forceConvert;
 
     /**
      * @var callable|null A PHP callback, which should be invoked to check whether asset conversion result is outdated.
-     * It will be invoked only if conversion target file exists and its modification time is older then the one of
-     * source file.
-     * Callback should match following signature:
-     *
-     * ```php
-     * function (string $basePath, string $sourceFile, string $targetFile, string $sourceExtension, string $targetExtension) : bool
-     * ```
-     *
-     * where $basePath is the asset source directory; $sourceFile is the asset source file path, relative to $basePath;
-     * $targetFile is the asset target file path, relative to $basePath; $sourceExtension is the source asset file
-     * extension and $targetExtension is the target asset file extension, respectively.
-     *
-     * It should return `true` is case asset should be reconverted.
-     * For example:
-     *
-     * ```php
-     * function ($basePath, $sourceFile, $targetFile, $sourceExtension, $targetExtension) {
-     *     if (YII_ENV !== 'dev') {
-     *         return false;
-     *     }
-     *
-     *     $resultModificationTime = @filemtime("$basePath/$result");
-     *     foreach (FileHelper::findFiles($basePath, ['only' => ["*.{$sourceExtension}"]]) as $filename) {
-     *         if ($resultModificationTime < @filemtime($filename)) {
-     *             return true;
-     *         }
-     *     }
-     *
-     *     return false;
-     * }
-     * ```
      */
     private $isOutdatedCallback = null;
 
     /**
      * @param Aliases $aliases The aliases instance.
      * @param LoggerInterface $logger The logger instance.
-     * @param array $commands The commands that are used to perform the asset conversion. {@see $commands}
+     * @param array $commands The commands that are used to perform the asset conversion.
+     * The keys are the asset file extension names, and the values are the corresponding
+     * target script types (either "css" or "js") and the commands used for the conversion.
+     *
+     * You may also use a {@see https://github.com/yiisoft/docs/blob/master/guide/en/concept/aliases.md}
+     * to specify the location of the command:
+     *
+     * ```php
+     * [
+     *     'styl' => ['css', '@app/node_modules/bin/stylus < {from} > {to}'],
+     * ]
+     * ```
      * @param bool $forceConvert Whether the source asset file should be converted even if its result already exists.
+     * See {@see withForceConvert()}.
      */
     public function __construct(
         Aliases $aliases,
@@ -163,9 +132,10 @@ final class AssetConverter implements AssetConverterInterface
     /**
      * Returns a new instance with the specified force convert value.
      *
-     * Make the conversion regardless of whether the asset already exists {@see $forceConvert}.
-     *
-     * @param bool $forceConvert
+     * @param bool $forceConvert Whether the source asset file should be converted even if its result already exists.
+     * Default is `false`. You may want to set this to be `true` during the development stage to make
+     * sure the converted assets are always up-to-date. Do not set this to true on production servers
+     * as it will significantly degrade the performance.
      *
      * @return self
      */
@@ -177,10 +147,40 @@ final class AssetConverter implements AssetConverterInterface
     }
 
     /**
-     * Returns a new instance with the specified is outdated callback value.
+     * Returns a new instance with a callback that is used to check for outdated result.
      *
-     * @param callable $isOutdatedCallback PHP callback, which should be invoked to
-     * check whether asset conversion result is outdated {@see $isOutdatedCallback}.
+     * @param callable $isOutdatedCallback A PHP callback, which should be invoked to check whether asset conversion result is outdated.
+     * It will be invoked only if conversion target file exists and its modification time is older then the one of
+     * source file.
+     * Callback should match following signature:
+     *
+     * ```php
+     * function (string $basePath, string $sourceFile, string $targetFile, string $sourceExtension, string $targetExtension) : bool
+     * ```
+     *
+     * where $basePath is the asset source directory; $sourceFile is the asset source file path, relative to $basePath;
+     * $targetFile is the asset target file path, relative to $basePath; $sourceExtension is the source asset file
+     * extension and $targetExtension is the target asset file extension, respectively.
+     *
+     * It should return `true` is case asset should be reconverted.
+     * For example:
+     *
+     * ```php
+     * function ($basePath, $sourceFile, $targetFile, $sourceExtension, $targetExtension) {
+     *     if (YII_ENV !== 'dev') {
+     *         return false;
+     *     }
+     *
+     *     $resultModificationTime = @filemtime("$basePath/$result");
+     *     foreach (FileHelper::findFiles($basePath, ['only' => ["*.{$sourceExtension}"]]) as $filename) {
+     *         if ($resultModificationTime < @filemtime($filename)) {
+     *             return true;
+     *         }
+     *     }
+     *
+     *     return false;
+     * }
+     * ```
      *
      * @return self
      */

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -21,34 +21,12 @@ final class AssetLoader implements AssetLoaderInterface
     private Aliases $aliases;
 
     /**
-     * @var bool Whether to append a timestamp to the URL of every published asset. Default is `false`.
-     * When this is true, the URL of a published asset may look like `/path/to/asset?v=timestamp`, where `timestamp`
-     * is the last modification time of the published asset file. You normally would want to set this property to true
-     * when you have enabled HTTP caching for assets, because it allows you to bust caching when the assets are updated.
+     * @var bool Whether to append a timestamp to the URL of every published asset.
      */
     private bool $appendTimestamp;
 
     /**
      * @var array<string, string> Mapping from source asset files (keys) to target asset files (values).
-     *
-     * Default is empty array. This property is provided to support fixing incorrect asset file paths in some
-     * asset bundles. When an asset bundle is registered with a view, each relative asset file in its
-     * {@see AssetBundle::$css} and {@see AssetBundle::$js} arrays will be examined against this map.
-     * If any of the keys is found to be the last part of an asset file (which is prefixed with
-     * {@see AssetBundle::$sourcePath} if available), the corresponding value will replace the asset
-     * and be registered with the view. For example, an asset file `my/path/to/jquery.js` matches a key `jquery.js`.
-     *
-     * Note that the target asset files should be absolute URLs, domain relative URLs (starting from '/') or paths
-     * relative to {@see $baseUrl} and {@see $basePath}.
-     *
-     * In the following example, any assets ending with `jquery.min.js` will be replaced with `jquery/dist/jquery.js`
-     * which is relative to {@see $baseUrl} and {@see $basePath}.
-     *
-     * ```php
-     * [
-     *     'jquery.min.js' => 'jquery/dist/jquery.js',
-     * ]
-     * ```
      */
     private array $assetMap;
 
@@ -76,10 +54,10 @@ final class AssetLoader implements AssetLoaderInterface
 
     /**
      * @param Aliases $aliases The aliases instance.
-     * @param bool $appendTimestamp Whether to append a timestamp to the URL {@see $appendTimestamp}.
-     * @param array<string, string> $assetMap Mapping from source asset files to target asset files {@see $assetMap}.
-     * @param string|null $basePath The root directory storing the asset files {@see $basePath}.
-     * @param string|null $baseUrl The base URL that can be used to access the asset files {@see $baseUrl}.
+     * @param bool $appendTimestamp Whether to append a timestamp to the URL of every published asset. See {@see withAppendTimestamp()}.
+     * @param array<string, string> $assetMap Mapping from source asset files to target asset files. See {@see withAssetMap()}.
+     * @param string|null $basePath The root directory storing the asset files. See {@see withBasePath()}.
+     * @param string|null $baseUrl The base URL that can be used to access the asset files. See {@see withBaseUrl()}.
      */
     public function __construct(
         Aliases $aliases,
@@ -158,7 +136,10 @@ final class AssetLoader implements AssetLoaderInterface
     /**
      * Returns a new instance with the specified append timestamp.
      *
-     * @param bool $appendTimestamp {@see $appendTimestamp}
+     * @param bool $appendTimestamp Whether to append a timestamp to the URL of every published asset. Default is `false`.
+     * When this is true, the URL of a published asset may look like `/path/to/asset?v=timestamp`, where `timestamp`
+     * is the last modification time of the published asset file. You normally would want to set this property to true
+     * when you have enabled HTTP caching for assets, because it allows you to bust caching when the assets are updated.
      *
      * @return self
      */
@@ -172,7 +153,26 @@ final class AssetLoader implements AssetLoaderInterface
     /**
      * Returns a new instance with the specified asset map.
      *
-     * @param array<string, string> $assetMap {@see $assetMap}
+     * @param array<string, string> $assetMap Mapping from source asset files (keys) to target asset files (values).
+     *
+     * Default is empty array. This property is provided to support fixing incorrect asset file paths in some
+     * asset bundles. When an asset bundle is registered with a view, each relative asset file in its
+     * {@see AssetBundle::$css} and {@see AssetBundle::$js} arrays will be examined against this map.
+     * If any of the keys is found to be the last part of an asset file (which is prefixed with
+     * {@see AssetBundle::$sourcePath} if available), the corresponding value will replace the asset
+     * and be registered with the view. For example, an asset file `my/path/to/jquery.js` matches a key `jquery.js`.
+     *
+     * Note that the target asset files should be absolute URLs, domain relative URLs (starting from '/') or paths
+     * relative to {@see withBaseUrl()} and {@see withBasePath()}.
+     *
+     * In the following example, any assets ending with `jquery.min.js` will be replaced with `jquery/dist/jquery.js`
+     * which is relative to {@see withBaseUrl()} and {@see withBasePath()}.
+     *
+     * ```php
+     * [
+     *     'jquery.min.js' => 'jquery/dist/jquery.js',
+     * ]
+     * ```
      *
      * @return self
      */
@@ -186,7 +186,7 @@ final class AssetLoader implements AssetLoaderInterface
     /**
      * Returns a new instance with the specified base path.
      *
-     * @param string|null $basePath {@see $basePath}
+     * @param string|null $basePath The root directory storing the asset files. Default is `null`.
      *
      * @return self
      */
@@ -200,7 +200,7 @@ final class AssetLoader implements AssetLoaderInterface
     /**
      * Returns a new instance with the specified base URL.
      *
-     * @param string|null $baseUrl {@see $baseUrl}
+     * @param string|null $baseUrl The base URL that can be used to access the asset files. Default is `null`.
      *
      * @return self
      */
@@ -214,7 +214,8 @@ final class AssetLoader implements AssetLoaderInterface
     /**
      * Returns a new instance with the specified global `$css` default options for all assets bundle.
      *
-     * @param array $cssDefaultOptions {@see $cssDefaultOptions}
+     * @param array $cssDefaultOptions The options that will be passed to {@see \Yiisoft\View\WebView::registerCssFile()}
+     * when registering the CSS files all assets bundle.
      *
      * @return self
      */
@@ -228,7 +229,8 @@ final class AssetLoader implements AssetLoaderInterface
     /**
      * Returns a new instance with the specified global `$js` default options for all assets bundle.
      *
-     * @param array $jsDefaultOptions {@see $jsDefaultOptions}
+     * @param array $jsDefaultOptions The options that will be passed to {@see \Yiisoft\View\WebView::registerJsFile()}
+     * when registering the JS files all assets bundle.
      *
      * @return self
      */
@@ -240,7 +242,8 @@ final class AssetLoader implements AssetLoaderInterface
     }
 
     /**
-     * If the asset bundle does not have a {@see AssetBundle::$basePath} set, the {@see $basePath} value is returned.
+     * If the asset bundle does not have a {@see AssetBundle::$basePath} set, the value set with {@see withBasePath()}
+     * is returned.
      *
      * @param AssetBundle $bundle
      *
@@ -256,7 +259,8 @@ final class AssetLoader implements AssetLoaderInterface
     }
 
     /**
-     * If the asset bundle does not have a {@see AssetBundle::$baseUrl} set, the {@see $baseUrl} value is returned.
+     * If the asset bundle does not have a {@see AssetBundle::$baseUrl} set, the value set with {@see withBaseUrl()}
+     * is returned.
      *
      * @param AssetBundle $bundle
      *

--- a/src/AssetLoaderInterface.php
+++ b/src/AssetLoaderInterface.php
@@ -18,8 +18,7 @@ interface AssetLoaderInterface
      * The actual URL is obtained by prepending {@see AssetBundle::$baseUrl} to the given asset path.
      *
      * @param AssetBundle $bundle The asset bundle which the asset file belongs to.
-     * @param string $assetPath The asset path. This should be one of the assets listed in {@see AssetBundle::$js} or
-     * {@see AssetBundle::$css}.
+     * @param string $assetPath The asset path. See {@see AssetBundle::$js} and {@see AssetBundle::$css}.
      *
      * @throws InvalidConfigException If asset files are not found.
      *

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -107,21 +107,6 @@ final class AssetManager
         return clone $bundle;
     }
 
-    public function getConverter(): ?AssetConverterInterface
-    {
-        return $this->converter;
-    }
-
-    public function getLoader(): AssetLoaderInterface
-    {
-        return $this->loader;
-    }
-
-    public function getPublisher(): ?AssetPublisherInterface
-    {
-        return $this->publisher;
-    }
-
     /**
      * Return config array CSS AssetBundle.
      *
@@ -163,24 +148,45 @@ final class AssetManager
     }
 
     /**
-     * Sets the asset converter.
+     * Returns a new instance with the specified converter.
      *
-     * @param AssetConverterInterface $converter The asset converter. This can be either an object implementing the
-     * {@see AssetConverterInterface}, or a configuration array that can be used to create the asset converter object.
+     * @param AssetConverterInterface $converter
+     *
+     * @return self
      */
-    public function setConverter(AssetConverterInterface $converter): void
+    public function withConverter(AssetConverterInterface $converter): self
     {
-        $this->converter = $converter;
+        $new = clone $this;
+        $new->converter = $converter;
+        return $new;
     }
 
     /**
-     * Sets the asset publisher.
+     * Returns a new instance with the specified loader.
+     *
+     * @param AssetLoaderInterface $loader
+     *
+     * @return self
+     */
+    public function withLoader(AssetLoaderInterface $loader): self
+    {
+        $new = clone $this;
+        $new->loader = $loader;
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified publisher.
      *
      * @param AssetPublisherInterface $publisher
+     *
+     * @return self
      */
-    public function setPublisher(AssetPublisherInterface $publisher): void
+    public function withPublisher(AssetPublisherInterface $publisher): self
     {
-        $this->publisher = $publisher;
+        $new = clone $this;
+        $new->publisher = $publisher;
+        return $new;
     }
 
     /**

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -56,7 +56,7 @@ final class AssetManager
      * @param AssetLoaderInterface $loader The loader instance.
      * @param string[] $allowedBundleNames List of names of allowed asset bundles. If the array is empty, then any
      * asset bundles are allowed. If the names of allowed asset bundles were specified, only these asset bundles
-     * or their dependencies can be registered {@see register()} and received {@see getBundle()}. Also, specifying
+     * or their dependencies can be registered {@see register()} and obtained {@see getBundle()}. Also, specifying
      * names allows to export {@see export()} asset bundles automatically without first registering them manually.
      * @param array $customizedBundles The asset bundle configurations. Provided to customize asset bundles.
      * When a bundle is being loaded by {@see getBundle()}, if it has a corresponding configuration specified

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -23,23 +23,12 @@ use function is_int;
 final class AssetManager
 {
     /**
-     * @var string[] List of names of allowed asset bundles.
-     * If the array is empty, then any asset bundles are allowed. Default to empty array.
-     *
-     * If the names of allowed asset bundles were specified, only these asset bundles or their dependencies can be
-     * registered {@see register()} and received {@see getBundle ()}. Also, specifying names allows to export
-     * {@see export()} asset bundles automatically without first registering them manually.
+     * @var string[] List of names of allowed asset bundles. If the array is empty, then any asset bundles are allowed.
      */
     private array $allowedBundleNames;
 
     /**
      * @var array The asset bundle configurations. This property is provided to customize asset bundles.
-     * When a bundle is being loaded by {@see getBundle()}, if it has a corresponding configuration
-     * specified here, the configuration will be applied to the bundle.
-     *
-     * The array keys are the asset class bundle names (without leading backslash).
-     * If a value is false, it means the corresponding asset bundle is disabled and {@see getBundle()}
-     * should return an instance of the specified asset bundle with empty property values.
      */
     private array $customizedBundles;
 
@@ -65,8 +54,15 @@ final class AssetManager
     /**
      * @param Aliases $aliases The aliases instance.
      * @param AssetLoaderInterface $loader The loader instance.
-     * @param string[] $allowedBundleNames List of names of allowed asset bundles {@see $allowedBundleNames}.
-     * @param array $customizedBundles The asset bundle configurations {@see $customizedBundles}.
+     * @param string[] $allowedBundleNames List of names of allowed asset bundles. If the array is empty, then any
+     * asset bundles are allowed. If the names of allowed asset bundles were specified, only these asset bundles
+     * or their dependencies can be registered {@see register()} and received {@see getBundle()}. Also, specifying
+     * names allows to export {@see export()} asset bundles automatically without first registering them manually.
+     * @param array $customizedBundles The asset bundle configurations. Provided to customize asset bundles.
+     * When a bundle is being loaded by {@see getBundle()}, if it has a corresponding configuration specified
+     * here, the configuration will be applied to the bundle. The array keys are the asset class bundle names
+     * (without leading backslash). If a value is false, it means the corresponding asset bundle is disabled
+     * and {@see getBundle()} should return an instance of the specified asset bundle with empty property values.
      */
     public function __construct(
         Aliases $aliases,
@@ -205,9 +201,9 @@ final class AssetManager
     }
 
     /**
-     * Exports registered asset bundles {@see $registeredBundles}.
+     * Exports registered asset bundles.
      *
-     * When using the allowed asset bundles {@see $allowedBundleNames}, the export result will always be the same,
+     * When using the allowed asset bundles, the export result will always be the same,
      * since the asset bundles are registered before the export. If do not use the allowed asset bundles mode,
      * must register {@see register()} all the required asset bundles before exporting.
      *
@@ -230,7 +226,7 @@ final class AssetManager
     }
 
     /**
-     * Registers asset bundles by names {@see $registeredBundles}.
+     * Registers asset bundles by names.
      *
      * @param string[] $names
      * @param int|null $position
@@ -253,7 +249,7 @@ final class AssetManager
     }
 
     /**
-     * Registers all allowed {@see $allowedBundleNames} asset bundles {@see $registeredBundles}.
+     * Registers all allowed asset bundles.
      *
      * @throws InvalidConfigException
      * @throws RuntimeException

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -108,6 +108,21 @@ final class AssetManager
     }
 
     /**
+     * Returns the actual URL for the specified asset.
+     *
+     * @param string $name The asset bundle name.
+     * @param string $path The asset path.
+     *
+     * @throws InvalidConfigException If asset files are not found.
+     *
+     * @return string The actual URL for the specified asset.
+     */
+    public function getAssetUrl(string $name, string $path): string
+    {
+        return $this->loader->getAssetUrl($this->getBundle($name), $path);
+    }
+
+    /**
      * Return config array CSS AssetBundle.
      *
      * @return array

--- a/src/AssetPublisher.php
+++ b/src/AssetPublisher.php
@@ -29,65 +29,26 @@ final class AssetPublisher implements AssetPublisherInterface
 
     /**
      * @var bool Whether the directory being published should be copied even if it is found in the target directory.
-     * Default is `false`. This option is used only when publishing a directory. You may want to set this to be `true`
-     * during thedevelopment stage to make sure the published directory is always up-to-date. Do not set this to true
-     * on production servers as it will significantly degrade the performance.
      */
     private bool $forceCopy;
 
     /**
-     * @var bool Whether to use symbolic link to publish asset files. Default is `false`, meaning asset files are
-     * copied to {@see AssetBundle::$basePath}. Using symbolic links has the benefit that the published assets
-     * will always be consistent with the source assets and there is no copy operation required.
-     * This is especially useful during development.
-     *
-     * However, there are special requirements for hosting environments in order to use symbolic links. In particular,
-     * symbolic links are supported only on Linux/Unix, and Windows Vista/2008 or greater.
-     *
-     * Moreover, some Web servers need to be properly configured so that the linked assets are accessible to Web users.
-     * For example, for Apache Web server, the following configuration directive should be added for the Web folder:
-     *
-     * ```apache
-     * Options FollowSymLinks
-     * ```
+     * @var bool Whether to use symbolic link to publish asset files.
      */
     private bool $linkAssets;
 
     /**
-     * @var int The permission to be set for newly generated asset directories. This value will be used by PHP chmod()
-     * function. No umask will be applied. Defaults to 0775, meaning the directory is read-writable by owner
-     * and group, but read-only for other users.
+     * @var int The permission to be set for newly generated asset directories.
      */
     private int $dirMode = 0775;
 
     /**
-     * @var int The permission to be set for newly published asset files. This value will be used by PHP chmod()
-     * function. No umask will be applied. If not set, the permission will be determined by the current
-     * environment.
+     * @var int The permission to be set for newly published asset files.
      */
     private int $fileMode = 0755;
 
     /**
-     * @var callable|null A callback that will be called to produce hash for asset directory generation. The signature
-     * of the callback should be as follows:
-     *
-     * ```
-     * function ($path)
-     * ```
-     *
-     * Where `$path` is the asset path. Note that the `$path` can be either directory where the asset files reside or a
-     * single file. For a CSS file that uses relative path in `url()`, the hash implementation should use the directory
-     * path of the file instead of the file path to include the relative asset files in the copying.
-     *
-     * If this is not set, the asset manager will use the default CRC32 and filemtime in the `hash` method.
-     *
-     * Example of an implementation using MD4 hash:
-     *
-     * ```php
-     * function (string $path): string {
-     *     return hash('md4', $path);
-     * }
-     * ```
+     * @var callable|null A callback that will be called to produce hash for asset directory generation.
      */
     private $hashCallback = null;
 
@@ -99,8 +60,8 @@ final class AssetPublisher implements AssetPublisherInterface
     /**
      * @param Aliases $aliases The aliases instance.
      * @param bool $forceCopy Whether the directory being published should be copied even
-     * if it is found in the target directory {@see $forceCopy}.
-     * @param bool $linkAssets Whether to use symbolic link to publish asset files {@see $linkAssets}.
+     * if it is found in the target directory. See {@see withForceCopy()}.
+     * @param bool $linkAssets Whether to use symbolic link to publish asset files. See {@see withLinkAssets()}.
      */
     public function __construct(Aliases $aliases, bool $forceCopy = false, bool $linkAssets = false)
     {
@@ -188,7 +149,9 @@ final class AssetPublisher implements AssetPublisherInterface
     /**
      * Returns a new instance with the specified directory mode.
      *
-     * @param int $dirMode The permission to be set for newly generated asset directories {@see $dirMode}.
+     * @param int $dirMode The permission to be set for newly generated asset directories. This value will be used
+     * by PHP `chmod()` function. No umask will be applied. Defaults to 0775, meaning the directory is read-writable
+     * by owner and group, but read-only for other users.
      *
      * @return self
      */
@@ -202,7 +165,9 @@ final class AssetPublisher implements AssetPublisherInterface
     /**
      * Returns a new instance with the specified files mode.
      *
-     * @param int $fileMode he permission to be set for newly published asset files. {@see $fileMode}.
+     * @param int $fileMode he permission to be set for newly published asset files. This value will be used
+     * by PHP `chmod()` function. No umask will be applied. If not set, the permission will be determined
+     * by the current environment.
      *
      * @return self
      */
@@ -216,8 +181,10 @@ final class AssetPublisher implements AssetPublisherInterface
     /**
      * Returns a new instance with the specified force copy value.
      *
-     * @param bool $forceCopy Whether the directory being published should be copied even
-     * if it is found in the target directory {@see $forceCopy}.
+     * @param bool $forceCopy Whether the directory being published should be copied even if it is found in the target
+     * directory. This option is used only when publishing a directory. You may want to set this to be `true` during
+     * the development stage to make sure the published directory is always up-to-date. Do not set this to `true`
+     * on production servers as it will significantly degrade the performance.
      *
      * @return self
      */
@@ -231,8 +198,26 @@ final class AssetPublisher implements AssetPublisherInterface
     /**
      * Returns a new instance with the specified force hash callback.
      *
-     * @param callable $hashCallback A callback that will be called to produce hash
-     * for asset directory generation {@see $hashCallback}.
+     * @param callable $hashCallback A callback that will be called to produce hash for asset directory generation.
+     * The signature of the callback should be as follows:
+     *
+     * ```
+     * function (string $path): string;
+     * ```
+     *
+     * Where `$path` is the asset path. Note that the `$path` can be either directory where the asset files reside or a
+     * single file. For a CSS file that uses relative path in `url()`, the hash implementation should use the directory
+     * path of the file instead of the file path to include the relative asset files in the copying.
+     *
+     * If this is not set, the asset manager will use the default CRC32 and filemtime in the `hash` method.
+     *
+     * Example of an implementation using MD4 hash:
+     *
+     * ```php
+     * function (string $path): string {
+     *     return hash('md4', $path);
+     * }
+     * ```
      *
      * @return self
      */
@@ -246,7 +231,20 @@ final class AssetPublisher implements AssetPublisherInterface
     /**
      * Returns a new instance with the specified link assets value.
      *
-     * @param bool $linkAssets Whether to use symbolic link to publish asset files {@see $linkAssets}.
+     * @param bool $linkAssets Whether to use symbolic link to publish asset files. Default is `false`,
+     * meaning asset files are copied to {@see AssetBundle::$basePath}. Using symbolic links has the benefit
+     * that the published assets will always be consistent with the source assets and there is no copy
+     * operation required. This is especially useful during development.
+     *
+     * However, there are special requirements for hosting environments in order to use symbolic links. In particular,
+     * symbolic links are supported only on Linux/Unix, and Windows Vista/2008 or greater.
+     *
+     * Moreover, some Web servers need to be properly configured so that the linked assets are accessible to Web users.
+     * For example, for Apache Web server, the following configuration directive should be added for the Web folder:
+     *
+     * ```apache
+     * Options FollowSymLinks
+     * ```
      *
      * @return self
      */

--- a/tests/AssetBundleTest.php
+++ b/tests/AssetBundleTest.php
@@ -68,7 +68,7 @@ final class AssetBundleTest extends TestCase
 
         $this->assertEmpty($this->getRegisteredBundles($manager));
 
-        $message = 'basePath must be set in AssetLoader->setBasePath($path)'
+        $message = 'basePath must be set in AssetLoader->withBasePath($path)'
             . ' or AssetBundle property public ?string $basePath = $path';
 
         $this->expectException(InvalidConfigException::class);
@@ -92,18 +92,16 @@ final class AssetBundleTest extends TestCase
 
     public function testBaseUrlIsNotSetException(): void
     {
-        $manager = new AssetManager($this->aliases, $this->loader, [], [
+        $manager = (new AssetManager($this->aliases, $this->loader, [], [
             BaseAsset::class => [
                 'basePath' => null,
                 'baseUrl' => null,
             ],
-        ]);
-
-        $this->manager->getLoader()->setBasePath('@asset');
+        ]))->withLoader($this->loader->withBasePath('@asset'));
 
         $this->assertEmpty($this->getRegisteredBundles($manager));
 
-        $message = 'baseUrl must be set in AssetLoader->setBaseUrl($path)'
+        $message = 'baseUrl must be set in AssetLoader->withBaseUrl($path)'
             . ' or AssetBundle property public ?string $baseUrl = $path';
 
         $this->expectException(InvalidConfigException::class);
@@ -112,23 +110,22 @@ final class AssetBundleTest extends TestCase
         $manager->register([BaseAsset::class]);
     }
 
-    public function testBasePathEmptyWithAssetManagerSetBasePath(): void
+    public function testBasePathEmptyWithAssetManagerWithBasePath(): void
     {
-        $this->manager->getLoader()->setBasePath('@asset');
+        $manager = $this->manager->withLoader($this->loader->withBasePath('@asset'));
 
-        $this->assertEmpty($this->getRegisteredBundles($this->manager));
-        $this->assertIsObject($this->manager->getBundle(BaseAsset::class));
-        $this->assertInstanceOf(BaseAsset::class, $this->manager->getBundle(BaseAsset::class));
+        $this->assertEmpty($this->getRegisteredBundles($manager));
+        $this->assertIsObject($manager->getBundle(BaseAsset::class));
+        $this->assertInstanceOf(BaseAsset::class, $manager->getBundle(BaseAsset::class));
     }
 
-    public function testBasePathEmptyBaseUrlEmptyWithAssetManagerSetBasePathSetBaseUrl(): void
+    public function testBasePathEmptyBaseUrlEmptyWithAssetManagerWithBasePathWithBaseUrl(): void
     {
-        $this->manager->getLoader()->setBasePath('@asset');
-        $this->manager->getLoader()->setBaseUrl('@assetUrl');
+        $manager = $this->manager->withLoader($this->loader->withBasePath('@asset')->withBaseUrl('@assetUrl'));
 
-        $this->assertEmpty($this->getRegisteredBundles($this->manager));
-        $this->assertIsObject($this->manager->getBundle(BaseAsset::class));
-        $this->assertInstanceOf(BaseAsset::class, $this->manager->getBundle(BaseAsset::class));
+        $this->assertEmpty($this->getRegisteredBundles($manager));
+        $this->assertIsObject($manager->getBundle(BaseAsset::class));
+        $this->assertInstanceOf(BaseAsset::class, $manager->getBundle(BaseAsset::class));
     }
 
     public function testBasePathWrongException(): void

--- a/tests/AssetLoaderTest.php
+++ b/tests/AssetLoaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Assets\Tests;
 
+use Yiisoft\Assets\AssetLoaderInterface;
 use Yiisoft\Assets\AssetManager;
 use Yiisoft\Assets\Tests\stubs\BaseAsset;
 use Yiisoft\Assets\Tests\stubs\CdnAsset;
@@ -16,10 +17,8 @@ final class AssetLoaderTest extends TestCase
 {
     public function testLoadBundleWithDefaultPathAndUrl(): void
     {
-        $this->loader->setBasePath('@asset');
-        $this->loader->setBaseUrl('@assetUrl');
-
-        $bundle = $this->loader->loadBundle(WithoutBaseAsset::class);
+        $loader = $this->loader->withBasePath('@asset')->withBaseUrl('@assetUrl');
+        $bundle = $loader->loadBundle(WithoutBaseAsset::class);
 
         $this->assertSame($this->aliases->get('@asset'), $bundle->basePath);
         $this->assertSame($this->aliases->get('@assetUrl'), $bundle->baseUrl);
@@ -28,7 +27,7 @@ final class AssetLoaderTest extends TestCase
     public function testBaseAppendTimestamp(): void
     {
         $bundle = new BaseAsset();
-        $manager = new AssetManager($this->aliases, $this->loader);
+        $manager = new AssetManager($this->aliases, $this->loader->withAppendTimestamp(true));
 
         $timestampCss = FileHelper::lastModifiedTime($this->aliases->get($bundle->basePath) . '/' . $bundle->css[0]);
         $urlCss = "/baseUrl/css/basePath.css?v=$timestampCss";
@@ -37,8 +36,6 @@ final class AssetLoaderTest extends TestCase
         $urlJs = "/baseUrl/js/basePath.js?v=$timestampJs";
 
         $this->assertEmpty($this->getRegisteredBundles($manager));
-
-        $this->loader->setAppendTimestamp(true);
 
         $manager->register([BaseAsset::class]);
 
@@ -62,12 +59,25 @@ final class AssetLoaderTest extends TestCase
         );
     }
 
-    public function testSetAssetMap(): void
+    public function testWithAssetMap(): void
     {
-        $manager = new AssetManager($this->aliases, $this->loader);
         $urlJs = '//testme.css';
+        $loader = $this->loader->withAssetMap(['jquery.js' => $urlJs]);
+        $manager = new AssetManager($this->aliases, $loader);
 
-        $this->loader->setAssetMap(['jquery.js' => $urlJs]);
+        $this->assertEmpty($this->getRegisteredBundles($manager));
+
+        $manager->register([JqueryAsset::class]);
+
+        $this->assertStringContainsString($urlJs, $manager->getJsFiles()[$urlJs]['url']);
+        $this->assertEquals(['position' => 3], $manager->getJsFiles()[$urlJs]['attributes']);
+    }
+
+    public function testWithAssetMapWithCustomizedBundles(): void
+    {
+        $urlJs = '//testme.css';
+        $loader = $this->loader->withAssetMap(['jquery.js' => $urlJs]);
+        $manager = new AssetManager($this->aliases, $loader, [], [JqueryAsset::class => ['js' => ['dist/jquery.js']]]);
 
         $this->assertEmpty($this->getRegisteredBundles($manager));
 
@@ -79,16 +89,43 @@ final class AssetLoaderTest extends TestCase
 
     public function testAssetUrlWithCdn(): void
     {
-        $this->loader->setBaseUrl('https://example.com/test');
+        $loader = $this->loader->withBaseUrl('https://example.com/test');
 
         $this->assertSame(
             'https://example.com/main.css',
-            $this->loader->getAssetUrl(new CdnAsset(), 'https://example.com/main.css'),
+            $loader->getAssetUrl(new CdnAsset(), 'https://example.com/main.css'),
         );
 
         $this->assertSame(
             'https://example.com/base/main.css',
-            $this->loader->getAssetUrl(new CdnWithBaseUrlAsset(), 'main.css'),
+            $loader->getAssetUrl(new CdnWithBaseUrlAsset(), 'main.css'),
         );
+    }
+
+    public function testSettersImmutability(): void
+    {
+        $loader = $this->loader->withAppendTimestamp(false);
+        $this->assertInstanceOf(AssetLoaderInterface::class, $loader);
+        $this->assertNotSame($this->loader, $loader);
+
+        $loader = $this->loader->withAssetMap([]);
+        $this->assertInstanceOf(AssetLoaderInterface::class, $loader);
+        $this->assertNotSame($this->loader, $loader);
+
+        $loader = $this->loader->withBasePath(null);
+        $this->assertInstanceOf(AssetLoaderInterface::class, $loader);
+        $this->assertNotSame($this->loader, $loader);
+
+        $loader = $this->loader->withBaseUrl(null);
+        $this->assertInstanceOf(AssetLoaderInterface::class, $loader);
+        $this->assertNotSame($this->loader, $loader);
+
+        $loader = $this->loader->withCssDefaultOptions([]);
+        $this->assertInstanceOf(AssetLoaderInterface::class, $loader);
+        $this->assertNotSame($this->loader, $loader);
+
+        $loader = $this->loader->withJsDefaultOptions([]);
+        $this->assertInstanceOf(AssetLoaderInterface::class, $loader);
+        $this->assertNotSame($this->loader, $loader);
     }
 }

--- a/tests/AssetManagerTest.php
+++ b/tests/AssetManagerTest.php
@@ -502,6 +502,34 @@ final class AssetManagerTest extends TestCase
         $this->manager->export(new JsonAssetExporter($this->aliases->get('@asset/test.json')));
     }
 
+    public function testGetAssetUrl(): void
+    {
+        $bundle = new ExportAsset();
+        $sourcePath = $this->aliases->get($bundle->sourcePath);
+        $hash = $this->getPublishedHash($sourcePath . FileHelper::lastModifiedTime($sourcePath), $this->publisher);
+
+        $this->assertSame(
+            $this->aliases->get("@assetUrl/{$hash}/css/stub.css"),
+            $this->manager->getAssetUrl(ExportAsset::class, 'css/stub.css'),
+        );
+        $this->assertSame(
+            $this->aliases->get("@assetUrl/{$hash}/js/stub.js"),
+            $this->manager->getAssetUrl(ExportAsset::class, 'js/stub.js'),
+        );
+        $this->assertSame(
+            $this->aliases->get("@assetUrl/{$hash}/export/stub.css"),
+            $this->manager->getAssetUrl(ExportAsset::class, 'export/stub.css'),
+        );
+        $this->assertSame(
+            $this->aliases->get("@assetUrl/{$hash}/export/stub.js"),
+            $this->manager->getAssetUrl(ExportAsset::class, 'export/stub.js'),
+        );
+        $this->assertSame(
+            $this->aliases->get("@assetUrl/{$hash}/export/yii-logo.png"),
+            $this->manager->getAssetUrl(ExportAsset::class, 'export/yii-logo.png'),
+        );
+    }
+
     public function testSettersImmutability(): void
     {
         $manager = $this->manager->withConverter($this->converter);

--- a/tests/Exporter/JsonAssetExporterTest.php
+++ b/tests/Exporter/JsonAssetExporterTest.php
@@ -60,7 +60,7 @@ final class JsonAssetExporterTest extends TestCase
             "{$exportBundle->sourcePath}/{$exportBundle->export[1]}",
         ]);
 
-        $manager->setPublisher($this->publisher);
+        $manager = $manager->withPublisher($this->publisher);
         $manager->export(new JsonAssetExporter($targetFile));
 
         $this->assertFileExists($targetFile);
@@ -93,7 +93,7 @@ final class JsonAssetExporterTest extends TestCase
             "{$exportBundle->sourcePath}/{$exportBundle->js[0]}",
         ]);
 
-        $manager->setPublisher($this->publisher);
+        $manager = $manager->withPublisher($this->publisher);
         $manager->export(new JsonAssetExporter($targetFile));
 
         $this->assertFileExists($targetFile);

--- a/tests/Exporter/WebpackAssetExporterTest.php
+++ b/tests/Exporter/WebpackAssetExporterTest.php
@@ -64,13 +64,13 @@ final class WebpackAssetExporterTest extends TestCase
                 'js' => ['js/stub.js'],
             ],
         ]);
-        $manager->setPublisher($this->publisher);
         $sourceBundle = new SourceAsset();
 
         $expected = "import '{$this->aliases->get($sourceBundle->sourcePath)}/{$sourceBundle->css[0]}';\n"
             . "import '{$this->aliases->get($sourceBundle->sourcePath)}/{$sourceBundle->js[0]}';\n"
         ;
 
+        $manager = $manager->withPublisher($this->publisher);
         $manager->export(new WebpackAssetExporter($targetFile));
 
         $this->assertFileExists($targetFile);

--- a/tests/stubs/BaseAsset.php
+++ b/tests/stubs/BaseAsset.php
@@ -14,20 +14,18 @@ use Yiisoft\Assets\AssetBundle;
  *
  * Note:
  *
- * - When not assigned $basePath, and $baseUrl they can be configured globally through the AssetPublisher.
+ * - When not assigned $basePath, and $baseUrl they can be configured globally through the AssetLoader.
  *
  * ```php
  * use Yiisoft\Assets\AssetPublisher;
  *
- * $assetPublisher = new AssetPublisher($aliases, $LoggerInterface);
- *
- * $assetPublisher->setBasePath($basePath);
- * $assetPublisher->setBaseUrl($baseUrl);
+ * $assetLoader = (new \Yiisoft\Assets\AssetLoader($aliases))
+ *     ->withBasePath($basePath)
+ *     ->withBaseUrl($baseUrl)
+ * ;
  * ```
  *
  * - The property array $publishOptions = [] is not available, since the AssetManager is not publishing anything.
- *
- * @package Assets
  */
 final class BaseAsset extends AssetBundle
 {

--- a/tests/stubs/BaseWrongAsset.php
+++ b/tests/stubs/BaseWrongAsset.php
@@ -12,8 +12,6 @@ use Yiisoft\Assets\Exception\InvalidConfigException;
  *
  * Example class with $basePath wrong.
  *
- * @package Assets
- *
  * @throws InvalidConfigException
  */
 final class BaseWrongAsset extends AssetBundle


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #4, #6

All assets/files located in the `AssetBundle::$sourcePath` directory are published. To get the actual URL for the specified asset, use:

```php
$assetManager->getAssetUrl(MyAsset::class, 'images/image.png');
$assetManager->getAssetUrl(MyAsset::class, 'docs/document.md');
```