### PR TITLE
Simplify set JS variables and strings

### DIFF
--- a/src/AssetBundle.php
+++ b/src/AssetBundle.php
@@ -121,7 +121,6 @@ class AssetBundle
 
     /**
      * @var array JavaScript variables to be passed to {@see \Yiisoft\View\WebView::registerJsVar()}.
-     * @psalm-var array<int,array{0:string,1:mixed}>|array<string,mixed>
      */
     public array $jsVars = [];
 

--- a/src/AssetBundle.php
+++ b/src/AssetBundle.php
@@ -121,8 +121,9 @@ class AssetBundle
 
     /**
      * @var array JavaScript variables to be passed to {@see \Yiisoft\View\WebView::registerJsVar()}.
+     * @psalm-var array<int,array{0:string,1:mixed}>|array<string,mixed>
      */
-    public array $jsVar = [];
+    public array $jsVars = [];
 
     /**
      * @var array The options to be passed to {@see AssetPublisherInterface::publish()} when the asset bundle

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -319,32 +319,6 @@ final class AssetManager
     }
 
     /**
-     * Registers a JavaScript code block.
-     *
-     * @param string $jsString The JavaScript code block to be registered.
-     * @param array $options The HTML attributes for the script tag. The following options are specially handled and
-     * are not treated as HTML attributes:
-     *
-     * - `position`: specifies where the JS script tag should be inserted in a page. The possible values are:
-     *     * {@see \Yiisoft\View\WebView::POSITION_HEAD} In the head section.
-     *     * {@see \Yiisoft\View\WebView::POSITION_BEGIN} At the beginning of the body section.
-     *     * {@see \Yiisoft\View\WebView::POSITION_END} At the end of the body section. This is the default value.
-     * @param string|null $key The key that identifies the JS code block. If null, it will use $jsString as the key.
-     * If two JS code blocks are registered with the same key, the latter will overwrite the former.
-     */
-    private function registerJsString(string $jsString, array $options = [], string $key = null): void
-    {
-        $key = $key ?: $jsString;
-
-        if (!array_key_exists('position', $options)) {
-            $options = array_merge(['position' => 3], $options);
-        }
-
-        $this->jsStrings[$key]['string'] = $jsString;
-        $this->jsStrings[$key]['attributes'] = $options;
-    }
-
-    /**
      * Converter SASS, SCSS, Stylus and other formats to CSS.
      *
      * @param AssetBundle $bundle
@@ -529,16 +503,7 @@ final class AssetManager
             }
         }
 
-        foreach ($bundle->jsStrings as $key => $jsString) {
-            $key = is_int($key) ? $jsString : $key;
-            if (is_array($jsString)) {
-                $string = array_shift($jsString);
-                $this->registerJsString($string, $jsString, $key);
-            } elseif ($jsString !== null) {
-                $this->registerJsString($jsString, $bundle->jsOptions, $key);
-            }
-        }
-
+        $this->jsStrings = array_merge($this->jsStrings, $bundle->jsStrings);
         $this->jsVars = array_merge($this->jsVars, $bundle->jsVars);
 
         foreach ($bundle->css as $css) {

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -15,7 +15,6 @@ use function array_unshift;
 use function in_array;
 use function is_array;
 use function is_file;
-use function is_int;
 
 /**
  * AssetManager manages asset bundle configuration and loading.

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -45,7 +45,7 @@ final class AssetManager
     private array $cssFiles = [];
     private array $jsFiles = [];
     private array $jsStrings = [];
-    private array $jsVar = [];
+    private array $jsVars = [];
     private ?AssetConverterInterface $converter = null;
     private ?AssetPublisherInterface $publisher = null;
     private AssetLoaderInterface $loader;
@@ -153,9 +153,9 @@ final class AssetManager
      *
      * @return array
      */
-    public function getJsVar(): array
+    public function getJsVars(): array
     {
-        return $this->jsVar;
+        return $this->jsVars;
     }
 
     /**
@@ -342,29 +342,6 @@ final class AssetManager
 
         $this->jsStrings[$key]['string'] = $jsString;
         $this->jsStrings[$key]['attributes'] = $options;
-    }
-
-    /**
-     * Registers a JS variable.
-     *
-     * @param string $varName The variable name.
-     * @param array|string $jsVar The JS code block to be registered.
-     * @param array $options The HTML attributes for the script tag. The following options are specially handled and
-     * are not treated as HTML attributes:
-     *
-     * - `position`: specifies where the JS script tag should be inserted in a page. The possible values are:
-     *     * {@see \Yiisoft\View\WebView::POSITION_HEAD} In the head section. This is the default value.
-     *     * {@see \Yiisoft\View\WebView::POSITION_BEGIN} At the beginning of the body section.
-     *     * {@see \Yiisoft\View\WebView::POSITION_END} At the end of the body section.
-     */
-    private function registerJsVar(string $varName, $jsVar, array $options = []): void
-    {
-        if (!array_key_exists('position', $options)) {
-            $options = array_merge(['position' => 1], $options);
-        }
-
-        $this->jsVar[$varName]['variables'] = $jsVar;
-        $this->jsVar[$varName]['attributes'] = $options;
     }
 
     /**
@@ -562,9 +539,7 @@ final class AssetManager
             }
         }
 
-        foreach ($bundle->jsVar as $key => $jsVar) {
-            $this->registerJsVar($key, $jsVar, $jsVar);
-        }
+        $this->jsVars = array_merge($this->jsVars, $bundle->jsVars);
 
         foreach ($bundle->css as $css) {
             if (is_array($css)) {

--- a/tests/AssetBundleTest.php
+++ b/tests/AssetBundleTest.php
@@ -203,7 +203,7 @@ final class AssetBundleTest extends TestCase
             [
                 'var1' => 'value1',
                 'var2' => [1, 2],
-                ['var3', 'value3', 'position' => 3],
+                ['var3', 'value3', 3],
             ],
             $this->manager->getJsVars(),
         );

--- a/tests/AssetBundleTest.php
+++ b/tests/AssetBundleTest.php
@@ -201,20 +201,11 @@ final class AssetBundleTest extends TestCase
 
         $this->assertEquals(
             [
-                'option1' => 'value1',
+                'var1' => 'value1',
+                'var2' => [1, 2],
+                ['var3', 'value3', 'position' => 3],
             ],
-            $this->manager->getJsVar()['var1']['variables'],
-        );
-        $this->assertEquals(
-            [
-                'option2' => 'value2',
-                'option3' => 'value3',
-            ],
-            $this->manager->getJsVar()['var2']['variables'],
-        );
-        $this->assertEquals(
-            3,
-            $this->manager->getJsVar()['var3']['attributes']['position'],
+            $this->manager->getJsVars(),
         );
     }
 

--- a/tests/AssetBundleTest.php
+++ b/tests/AssetBundleTest.php
@@ -181,17 +181,14 @@ final class AssetBundleTest extends TestCase
     {
         $this->manager->register([BaseAsset::class]);
 
-        $this->assertEquals(
-            'app1.start();',
-            $this->manager->getJsStrings()['uniqueName']['string'],
-        );
-        $this->assertEquals(
-            'app2.start();',
-            $this->manager->getJsStrings()['app2.start();']['string'],
-        );
-        $this->assertEquals(
-            1,
-            $this->manager->getJsStrings()['uniqueName2']['attributes']['position'],
+        $this->assertSame(
+            [
+                'uniqueName' => 'app1.start();',
+                'app2.start();',
+                'uniqueName2' => ['app3.start();', 3],
+                ['app4.start();', 3],
+            ],
+            $this->manager->getJsStrings(),
         );
     }
 
@@ -199,7 +196,7 @@ final class AssetBundleTest extends TestCase
     {
         $this->manager->register([BaseAsset::class]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'var1' => 'value1',
                 'var2' => [1, 2],

--- a/tests/stubs/BaseAsset.php
+++ b/tests/stubs/BaseAsset.php
@@ -54,12 +54,12 @@ final class BaseAsset extends AssetBundle
     public array $jsStrings = [
         'uniqueName' => 'app1.start();',
         'app2.start();',
-        'uniqueName2' => ['app3.start();', 'position' => 1], //WebView::POSITION_HEAD
+        'uniqueName2' => ['app3.start();', 'position' => 1], // WebView::POSITION_HEAD
     ];
 
-    public array $jsVar = [
-        'var1' => ['option1' => 'value1'],
-        'var2' => ['option2' => 'value2', 'option3' => 'value3'],
-        'var3' => [['option4' => 'value4'], 'position' => 3], //WebView::POSITION_END
+    public array $jsVars = [
+        'var1' => 'value1',
+        'var2' => [1, 2],
+        ['var3', 'value3', 'position' => 3], // WebView::POSITION_END
     ];
 }

--- a/tests/stubs/BaseAsset.php
+++ b/tests/stubs/BaseAsset.php
@@ -54,7 +54,8 @@ final class BaseAsset extends AssetBundle
     public array $jsStrings = [
         'uniqueName' => 'app1.start();',
         'app2.start();',
-        'uniqueName2' => ['app3.start();', 'position' => 1], // WebView::POSITION_HEAD
+        'uniqueName2' => ['app3.start();', 3],
+        ['app4.start();', 3],
     ];
 
     public array $jsVars = [

--- a/tests/stubs/BaseAsset.php
+++ b/tests/stubs/BaseAsset.php
@@ -60,6 +60,6 @@ final class BaseAsset extends AssetBundle
     public array $jsVars = [
         'var1' => 'value1',
         'var2' => [1, 2],
-        ['var3', 'value3', 'position' => 3], // WebView::POSITION_END
+        ['var3', 'value3', 3],
     ];
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

1. Rename `AssetManager::getJsVar()` to `AssetManager::getJsVars()`.

2. Allow any format of JS variables.

3. Allow any format of JS strings.

Related to https://github.com/yiisoft/view/pull/145

Adopt PRs: https://github.com/yiisoft/yii-demo/pull/294 and https://github.com/yiisoft/app/pull/157