### PR TITLE
Fix export interface violation for JsonAssetExporter

### DIFF
--- a/src/Exporter/JsonAssetExporter.php
+++ b/src/Exporter/JsonAssetExporter.php
@@ -31,11 +31,17 @@ final class JsonAssetExporter implements AssetExporterInterface
     /**
      * {@inheritDoc}
      *
-     * @throws JsonException If an error occurred during JSON encoding of asset bundles.
      * @throws RuntimeException If an error occurred while writing to the JSON file.
      */
     public function export(array $assetBundles): void
     {
-        AssetUtil::exportToFile($this->targetFile, Json::encode(AssetUtil::extractFilePathsForExport($assetBundles)));
+        try {
+            AssetUtil::exportToFile(
+                $this->targetFile,
+                Json::encode(AssetUtil::extractFilePathsForExport($assetBundles)),
+            );
+        } catch (JsonException $e) {
+            throw new RuntimeException('An error occurred during JSON encoding of asset bundles.', 0, $e);
+        }
     }
 }

--- a/src/Exporter/JsonAssetExporter.php
+++ b/src/Exporter/JsonAssetExporter.php
@@ -36,12 +36,11 @@ final class JsonAssetExporter implements AssetExporterInterface
     public function export(array $assetBundles): void
     {
         try {
-            AssetUtil::exportToFile(
-                $this->targetFile,
-                Json::encode(AssetUtil::extractFilePathsForExport($assetBundles)),
-            );
+            $data = Json::encode(AssetUtil::extractFilePathsForExport($assetBundles));
         } catch (JsonException $e) {
             throw new RuntimeException('An error occurred during JSON encoding of asset bundles.', 0, $e);
         }
+
+        AssetUtil::exportToFile($this->targetFile, $data);
     }
 }

--- a/tests/Exporter/JsonAssetExporterTest.php
+++ b/tests/Exporter/JsonAssetExporterTest.php
@@ -141,7 +141,7 @@ final class JsonAssetExporterTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('An error occurred during JSON encoding of asset bundles.');
 
-        $exporter->export([new class extends AssetBundle {
+        $exporter->export([new class() extends AssetBundle {
             public ?string $basePath = '@asset';
             public ?string $baseUrl = '@assetUrl';
             public ?string $sourcePath = '@sourcePath';

--- a/tests/Exporter/JsonAssetExporterTest.php
+++ b/tests/Exporter/JsonAssetExporterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Assets\Tests\Exporter;
 
 use RuntimeException;
+use Yiisoft\Assets\AssetBundle;
 use Yiisoft\Assets\AssetManager;
 use Yiisoft\Assets\AssetUtil;
 use Yiisoft\Assets\Exporter\JsonAssetExporter;
@@ -129,6 +130,22 @@ final class JsonAssetExporterTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Target directory \"{$targetDirectory}\" does not exist or is not writable.");
 
-        $exporter->export([ExportAsset::class => new ExportAsset()]);
+        $exporter->export([new ExportAsset()]);
+    }
+
+    public function testExportToJsonFileThrowExceptionForErrorOccurredDuringJsonEncoding(): void
+    {
+        $targetFile = $this->aliases->get('@exporter/test.json');
+        $exporter = new JsonAssetExporter($targetFile);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('An error occurred during JSON encoding of asset bundles.');
+
+        $exporter->export([new class extends AssetBundle {
+            public ?string $basePath = '@asset';
+            public ?string $baseUrl = '@assetUrl';
+            public ?string $sourcePath = '@sourcePath';
+            public array $css = ["\xB1\x31"];
+        }]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

`AssetExporterInterface` requires to be thrown `RuntimeException` if an error occurred during the export. But the `JsonAssetExporter` may throw an `JsonException` during JSON encoding.
