### PR TITLE
Fix bug when associative array is passed

### DIFF
--- a/src/AssetRegistrar.php
+++ b/src/AssetRegistrar.php
@@ -243,7 +243,7 @@ final class AssetRegistrar
          */
         foreach ($bundle->js as $i => $js) {
             if (is_array($js)) {
-                $file = $js[0];
+                $file = $i;
                 if (AssetUtil::isRelative($file)) {
                     $baseFile = $this->aliases->get("{$bundle->basePath}/{$file}");
                     if (is_file($baseFile)) {


### PR DESCRIPTION
The convert... methods will trigger whenever there are assetConverters available. This error triggers whevener JS files are specified with options; to take advantage of the attributes of the <script> tag. This change ensures that we use the correct URL when converting the file.

The use case which prompted this is import-maps. For import-maps, we would need to define JS script tags as modules and as import maps. With this change, script files can be defined independently ann injected with different types. A cleaner way to do this would be to have methods like "addJsModules()" and "addJsImportMaps()" to explicitly support this use case. This is a band-aid fix.

## How to trigger?

In `src/Asset/AppAsset.php`

```php
    public array $js = [
        'js/site.js' => [
            'foo' => 'bar',
        ]
    ];
```

Ideally (and with this fix), this should generate a script like so

```html
<script src="/assets/br34d3d/js/site.js" foo="bar"></script>
```

…instead, it errors out.


| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | 🤷🏾‍♂️