### PR TITLE
AssetManager load empty AssetBundle when register wrong namespace bundle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.1.0 under development
 
-- Fix #123: AssetManager load empty AssetBundle when register wrong namespace bundle (@terabytesoftw)
+- Bug #123: `AssetManager` load empty `AssetBundle` when register wrong namespace bundle (@terabytesoftw)
 - Enh #119: Add debug collector for yiisoft/yii-debug (@xepozz)
 
 ## 4.0.0 February 13, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.1.0 under development
 
+- Fix #123: AssetManager load empty AssetBundle when register wrong namespace bundle (@terabytesoftw)
 - Enh #119: Add debug collector for yiisoft/yii-debug (@xepozz)
 
 ## 4.0.0 February 13, 2023

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,18 @@
     "require": {
         "php": "^8.0",
         "ext-mbstring": "*",
-        "psr/log": "^1.1|^2.0|^3.0",
-        "yiisoft/aliases": "^1.1|^2.0|^3.0",
+        "psr/log": "^3.0",
+        "yiisoft/aliases": "^3.0",
         "yiisoft/files": "^2.0",
         "yiisoft/json": "^1.0"
     },
     "require-dev": {
-        "maglnet/composer-require-checker": "^4.2",
+        "maglnet/composer-require-checker": "^4.3",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^0.15.3",
-        "roave/infection-static-analysis-plugin": "^1.16",
+        "rector/rector": "^0.16",
+        "roave/infection-static-analysis-plugin": "^1.26|^1.31",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.30|^5.6",
+        "vimeo/psalm": "^4.30|^5.8",
         "yiisoft/di": "^1.2",
         "yiisoft/test-support": "^3.0",
         "yiisoft/yii-debug": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php": "^8.0",
         "ext-mbstring": "*",
-        "psr/log": "^3.0",
-        "yiisoft/aliases": "^3.0",
+        "psr/log": "^1.1|^2.0|^3.0",
+        "yiisoft/aliases": "^1.1|^2.0|^3.0",
         "yiisoft/files": "^2.0",
         "yiisoft/json": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "maglnet/composer-require-checker": "^4.3",
         "phpunit/phpunit": "^9.5",
         "rector/rector": "^0.16",
-        "roave/infection-static-analysis-plugin": "^1.26|^1.31",
+        "roave/infection-static-analysis-plugin": "^1.25|^1.31",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.30|^5.8",
         "yiisoft/di": "^1.2",

--- a/src/AssetLoaderInterface.php
+++ b/src/AssetLoaderInterface.php
@@ -27,7 +27,7 @@ interface AssetLoaderInterface
     public function getAssetUrl(AssetBundle $bundle, string $assetPath): string;
 
     /**
-     * Loads an asset bundle class by name or creates an instance of the asset bundle class.
+     * Loads an asset bundle class by name or creates an instance of the asset bundle class, if class name not exists.
      *
      * @param string $name The asset bundle name.
      * @param array $config The asset bundle instance configuration.

--- a/src/AssetLoaderInterface.php
+++ b/src/AssetLoaderInterface.php
@@ -27,7 +27,7 @@ interface AssetLoaderInterface
     public function getAssetUrl(AssetBundle $bundle, string $assetPath): string;
 
     /**
-     * Loads an asset bundle class by name.
+     * Loads an asset bundle class by name or creates an instance of the asset bundle class.
      *
      * @param string $name The asset bundle name.
      * @param array $config The asset bundle instance configuration.

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Assets;
 
+use InvalidArgumentException;
 use RuntimeException;
 use Yiisoft\Aliases\Aliases;
 use Yiisoft\Assets\Exception\InvalidConfigException;
@@ -250,7 +251,11 @@ final class AssetManager
     }
 
     /**
-     * Registers asset bundle by name with custom configuration.
+     * Registers an asset bundle by name with custom configuration.
+     *
+     * This method is similar to {@see register()}, except that it allows you to customize the asset bundle
+     * configuration before it is registered. It also supports registering asset bundles with virtual namespaces,
+     * which means that the corresponding asset file may not physically exist.
      *
      * @param string $bundleName The class name of the asset bundle (without the leading backslash).
      * @param array $bundleConfig The customized asset bundle configuration.
@@ -418,6 +423,7 @@ final class AssetManager
         }
 
         if (!isset($this->customizedBundles[$name])) {
+            $this->validateAssetBundleClass($name);
             return $this->loadedBundles[$name] = $this->loader->loadBundle($name);
         }
 
@@ -499,5 +505,12 @@ final class AssetManager
         }
 
         return false;
+    }
+
+    private function validateAssetBundleClass(string $class): void
+    {
+        if (!class_exists($class)) {
+            throw new InvalidConfigException("The \"{$class}\" asset bundle class does not exist.");
+        }
     }
 }

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Assets;
 
-use InvalidArgumentException;
 use RuntimeException;
 use Yiisoft\Aliases\Aliases;
 use Yiisoft\Assets\Exception\InvalidConfigException;

--- a/tests/AssetManagerTest.php
+++ b/tests/AssetManagerTest.php
@@ -787,7 +787,6 @@ final class AssetManagerTest extends TestCase
         $this->assertSame(['/js/jquery.js'], $manager->getJsFiles()['/js/jquery.js']);
     }
 
-
     /**
      * @link https://github.com/yiisoft/assets/issues/123
      */

--- a/tests/AssetManagerTest.php
+++ b/tests/AssetManagerTest.php
@@ -769,6 +769,51 @@ final class AssetManagerTest extends TestCase
         );
     }
 
+    public function testRegisterCustomizedVirtualAsset(): void
+    {
+        $manager = new AssetManager($this->aliases, $this->loader);
+
+        $manager->registerCustomized(
+            VirtualAsset::class,
+            [
+                'basePath' => '@root/tests/public/jquery',
+                'baseUrl' => '/js',
+                'js' => [
+                    ['jquery.js'],
+                ],
+            ],
+        );
+
+        $this->assertSame(['/js/jquery.js'], $manager->getJsFiles()['/js/jquery.js']);
+    }
+
+
+    /**
+     * @link https://github.com/yiisoft/assets/issues/123
+     */
+    public function testRegisterWrongNameSpace(): void
+    {
+        $manager = new AssetManager($this->aliases, $this->loader);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('The "yii\bootstrap\BootstrapAsset" asset bundle class does not exist.');
+
+        $manager->register('yii\bootstrap\BootstrapAsset');
+    }
+
+    /**
+     * @link https://github.com/yiisoft/assets/issues/123
+     */
+    public function testRegisterManyWrongNameSpace(): void
+    {
+        $manager = new AssetManager($this->aliases, $this->loader);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('The "yii\bootstrap\BootstrapAsset" asset bundle class does not exist.');
+
+        $manager->registerMany(['yii\bootstrap\BootstrapAsset']);
+    }
+
     private function createManager(array $aliases = []): AssetManager
     {
         $aliases = new Aliases($aliases);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Issue | https://github.com/yiisoft/assets/issues/123
